### PR TITLE
Wait for postgres to be ready before creating app container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,11 @@ services:
       POSTGRES_DB: csvbase
     networks:
       csvbase:
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   csvbase:
     build: .
@@ -20,7 +25,8 @@ services:
     networks:
       csvbase:
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
 
 networks:
   csvbase:


### PR DESCRIPTION
Ran into this while trying to bring up the docker-compose file for the first time, The app container tries to connect to the db before postgres is listening:

```
csvbase_1   | psycopg2.OperationalError: connection to server at "postgres" (172.18.0.2), port 5432 failed: Connection refused
csvbase_1   |   Is the server running on that host and accepting TCP/IP connections?
```
Solution copypasta'd [from stackoverflow](https://stackoverflow.com/questions/35069027/docker-wait-for-postgresql-to-be-running).
