### PR TITLE
Fix Flask entrypoint in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,11 @@ COPY --from=builder wheelhouse wheelhouse
 
 RUN python -m pip --no-cache-dir install csvbase --no-index -f wheelhouse
 
-ENV FLASK_APP=csvbase.web:init_app()
+ENV FLASK_APP=csvbase.web.app:init_app()
 ENV FLASK_DEBUG=0
 COPY alembic.ini .
 COPY migrations migrations
 EXPOSE 6001
 ENTRYPOINT ["/tini", "--"]
-CMD ["gunicorn", "csvbase.web:init_app()", "-b", ":6001"]
+CMD ["gunicorn", "csvbase.web.app:init_app()", "-b", ":6001"]
 


### PR DESCRIPTION
Hey, first of all thanks for your amazing project!

Currently running `ghcr.io/calpaterson/csvbase:latest` I got the following error:

```txt
[2023-09-15 20:54:32 +0000] [7] [INFO] Starting gunicorn 20.1.0
[2023-09-15 20:54:32 +0000] [7] [INFO] Listening at: http://0.0.0.0:6001 (7)
[2023-09-15 20:54:32 +0000] [7] [INFO] Using worker: sync
[2023-09-15 20:54:32 +0000] [9] [INFO] Booting worker with pid: 9
Failed to find attribute 'init_app' in 'csvbase.web'.
[2023-09-15 20:54:32 +0000] [9] [INFO] Worker exiting (pid: 9)
[2023-09-15 20:54:32 +0000] [7] [INFO] Shutting down: Master
[2023-09-15 20:54:32 +0000] [7] [INFO] Reason: App failed to load.
```

Looks like Dockerfile was [overlooked in this commit](https://github.com/calpaterson/csvbase/commit/1d81dc5b2dbc2b395c60c2af673c5e9a556939fa), when the legacy import was removed. This PR fixes that.