### PR TITLE
Registration validations on table upload/paste table

### DIFF
--- a/csvbase/svc.py
+++ b/csvbase/svc.py
@@ -378,6 +378,10 @@ def check_username_is_allowed(sesh: Session, username: str) -> None:
     if is_prohibited:
         logger.warning("username prohibited: %s", username)
         raise exc.ProhibitedUsernameException()
+    if username_exists(sesh, username):
+        raise exc.UsernameAlreadyExistsException(username)
+    if username_exists_insensitive(sesh, username):
+        raise exc.UsernameAlreadyExistsInDifferentCaseException(username)
 
 
 def is_correct_password(

--- a/csvbase/web/main/bp.py
+++ b/csvbase/web/main/bp.py
@@ -1315,10 +1315,6 @@ def register() -> Response:
     else:
         sesh = get_sesh()
         username = request.form["username"]
-        if svc.username_exists(sesh, username):
-            raise exc.UsernameAlreadyExistsException(username)
-        if svc.username_exists_insensitive(sesh, username):
-            raise exc.UsernameAlreadyExistsInDifferentCaseException(username)
 
         user = svc.create_user(
             sesh,


### PR DESCRIPTION
Hello, fixes #76 when creating a table from a file, and when pasting a table.

If a user is not logged in and tries to create a blank table, they get redirected to the registration page even if they have entered a username and password. There is a test marked xfail for it already. Will I create an issue for this?
