### PR TITLE
Allow registration when creating blank table

### DIFF
--- a/csvbase/web/main/bp.py
+++ b/csvbase/web/main/bp.py
@@ -305,9 +305,20 @@ def blank_table() -> str:
 
 @bp.post("/new-table/blank")
 def blank_table_form_post() -> Response:
-    current_user = get_current_user_or_401()
-
     sesh = get_sesh()
+    if "username" in request.form:
+        current_user = svc.create_user(
+            sesh,
+            current_app.config["CRYPT_CONTEXT"],
+            request.form["username"],
+            request.form["password"],
+            request.form.get("email"),
+        )
+        sign_in_user(current_user)
+        flash("Account registered")
+    else:
+        current_user = get_current_user_or_401()
+
     quota = billing_svc.get_quota(sesh, current_user.user_uuid)
     usage = svc.get_usage(sesh, current_user.user_uuid)
     if "private" in request.form:

--- a/tests/test_create_table_via_form_post.py
+++ b/tests/test_create_table_via_form_post.py
@@ -290,11 +290,14 @@ def test_blank_table(client, test_user):
     assert resp1.status_code == 302
 
 
-@pytest.mark.xfail(reason="actual bug, needs fixing")
 def test_blank_table__and_register(client):
+    username = f"test-{random_string()}"
+
     resp1 = client.post(
         "/new-table/blank",
         data={
+            "username": username,
+            "password": "password",
             "col-name-1": "test",
             "col-type-1": "TEXT",
             "table-name": random_string(),


### PR DESCRIPTION
Hello,
Fixes #96 
Creates a function for registration and signing in to be re-used in the three endpoints a user can simultaneously create a table and sign-in.

I didn't include the conditions in the method as I felt they should be visible where the function is called (and couldn't think of a good concise name for a function that checks username is present then registers then signs in or gets current user or 401s)
Thanks.