### PR TITLE
Merge export endpoints into table_view_with_extension

### DIFF
--- a/csvbase/web/templates/table_export.html
+++ b/csvbase/web/templates/table_export.html
@@ -5,7 +5,7 @@
   <div class="container">
     <div class="row mb-3">
       <h2>Export to MS Excel</h2>
-      <form action="{{ url_for('csvbase.export_table_xlsx', username=table.username, table_name=table.table_name) }}">
+      <form action="{{ url_for('csvbase.table_view_with_extension', username=table.username, table_name=table.table_name, extension='xlsx') }}">
         <div class="mb-3 form-check">
           <input type="checkbox" class="form-check-input" disabled checked id="excel-row-id" name="row-id">
           <label class="form-check-label" for="excel-row-id">Include <code>csvbase_row_id</code></label>
@@ -22,7 +22,7 @@
 
     <div class="row mb-3">
       <h2>Export to CSV/TSV</h2>
-      <form action="{{ url_for('csvbase.export_table_csv', username=table.username, table_name=table.table_name) }}">
+      <form action="{{ url_for('csvbase.table_view_with_extension', username=table.username, table_name=table.table_name, extension='csv') }}">
         <div class="mb-3 form-check">
           <input type="checkbox" class="form-check-input" disabled checked id="excel-row-id" name="row-id">
           <label class="form-check-label" for="excel-row-id">Include <code>csvbase_row_id</code></label>

--- a/csvbase/web/templates/table_macros.html
+++ b/csvbase/web/templates/table_macros.html
@@ -55,7 +55,7 @@
       {# <p>{{ praise_button(table, None) }}</p> #}
       <a class="card-link" href="{{ url_for('csvbase.table_view', username=table.username, table_name=table.table_name) }}">View</a>
       <a class="card-link" href="{{ url_for('csvbase.get_table_apidocs', username=table.username, table_name=table.table_name) }}">API</a>
-      <a class="card-link" href="{{ url_for('csvbase.export_table_csv', username=table.username, table_name=table.table_name) }}">Download CSV</a>
+      <a class="card-link" href="{{ url_for('csvbase.table_view_with_extension', username=table.username, table_name=table.table_name, extension='csv') }}">Download CSV</a>
     </div>
   </div>
 {% endmacro %}


### PR DESCRIPTION
Hello,
Merges the functions export_table_csv and export_table_xlsx and their routes into table_view_with_extension. 
Modifies the table_export and table_macros templates to generate their links using the routing linked to table_view_with_extension using the extension parameter.

Both <table_name>.<extension> and <table_name>/export/\<extension\> are available but the links in the html pages seem to always be built using the <table_name>/export/\<extension\> format regardless.