### PR TITLE
Fix blank emails when registering

### DIFF
--- a/csvbase/models.py
+++ b/csvbase/models.py
@@ -81,7 +81,10 @@ class User(Base):
 
 class UserEmail(Base):
     __tablename__ = "user_emails"
-    __table_args__ = (METADATA_SCHEMA_TABLE_ARG,)
+    __table_args__ = (
+        CheckConstraint("email_address <> ''", "email_address_blank"),
+        METADATA_SCHEMA_TABLE_ARG,
+    )
 
     user_uuid = Column(PGUUID, ForeignKey("metadata.users.user_uuid"), primary_key=True)
     email_address = Column(satypes.String(length=200), nullable=False, index=True)

--- a/csvbase/models.py
+++ b/csvbase/models.py
@@ -82,7 +82,7 @@ class User(Base):
 class UserEmail(Base):
     __tablename__ = "user_emails"
     __table_args__ = (
-        CheckConstraint("email_address != ''", "ck_email_address_not_blank"),
+        CheckConstraint("email_address != ''", "email_address_not_blank"),
         METADATA_SCHEMA_TABLE_ARG,
     )
 

--- a/csvbase/models.py
+++ b/csvbase/models.py
@@ -82,7 +82,7 @@ class User(Base):
 class UserEmail(Base):
     __tablename__ = "user_emails"
     __table_args__ = (
-        CheckConstraint("email_address != ''", "email_address_not_blank"),
+        CheckConstraint("email_address ~ '@'", "email_address_not_blank"),
         METADATA_SCHEMA_TABLE_ARG,
     )
 

--- a/csvbase/models.py
+++ b/csvbase/models.py
@@ -82,7 +82,7 @@ class User(Base):
 class UserEmail(Base):
     __tablename__ = "user_emails"
     __table_args__ = (
-        CheckConstraint("email_address <> ''", "ck_email_address_not_blank"),
+        CheckConstraint("email_address != ''", "ck_email_address_not_blank"),
         METADATA_SCHEMA_TABLE_ARG,
     )
 

--- a/csvbase/models.py
+++ b/csvbase/models.py
@@ -82,7 +82,7 @@ class User(Base):
 class UserEmail(Base):
     __tablename__ = "user_emails"
     __table_args__ = (
-        CheckConstraint("email_address <> ''", "email_address_blank"),
+        CheckConstraint("email_address <> ''", "ck_email_address_not_blank"),
         METADATA_SCHEMA_TABLE_ARG,
     )
 

--- a/csvbase/svc.py
+++ b/csvbase/svc.py
@@ -160,6 +160,7 @@ def update_user(sesh, new_user: User) -> None:
 def update_user_email(sesh, user: User) -> None:
     if user.email == "":
         logger.warning("empty string email address")
+    # HTML forms submit empty fields as blank strings.
     if user.email is None or user.email == "":
         sesh.query(models.UserEmail).filter(
             models.UserEmail.user_uuid == user.user_uuid
@@ -338,7 +339,7 @@ def create_user(
         timezone="UTC",
         registered=registered,
     )
-
+    # HTML forms submit empty fields as blank strings.
     if email is not None and email != "":
         user.email_obj = models.UserEmail(email_address=email)
     user.api_key = models.APIKey(api_key=secrets.token_bytes(16))

--- a/csvbase/svc.py
+++ b/csvbase/svc.py
@@ -160,7 +160,7 @@ def update_user(sesh, new_user: User) -> None:
 def update_user_email(sesh, user: User) -> None:
     if user.email == "":
         logger.warning("empty string email address")
-    if user.email is None:
+    if user.email is None or user.email == "":
         sesh.query(models.UserEmail).filter(
             models.UserEmail.user_uuid == user.user_uuid
         ).delete()
@@ -339,7 +339,7 @@ def create_user(
         registered=registered,
     )
 
-    if email is not None:
+    if email is not None and email != "":
         user.email_obj = models.UserEmail(email_address=email)
     user.api_key = models.APIKey(api_key=secrets.token_bytes(16))
 

--- a/csvbase/svc.py
+++ b/csvbase/svc.py
@@ -161,7 +161,7 @@ def update_user_email(sesh, user: User) -> None:
     if user.email == "":
         logger.warning("empty string email address")
     # HTML forms submit empty fields as blank strings.
-    if user.email is None or user.email == "":
+    if user.email is None or "@" not in user.email:
         sesh.query(models.UserEmail).filter(
             models.UserEmail.user_uuid == user.user_uuid
         ).delete()
@@ -340,7 +340,7 @@ def create_user(
         registered=registered,
     )
     # HTML forms submit empty fields as blank strings.
-    if email is not None and email != "":
+    if email is not None and "@" in email:
         user.email_obj = models.UserEmail(email_address=email)
     user.api_key = models.APIKey(api_key=secrets.token_bytes(16))
 

--- a/csvbase/value_objs.py
+++ b/csvbase/value_objs.py
@@ -52,6 +52,9 @@ class User:
             logger.exception("unable to load timezone for user, using UTC")
             return timezone.utc
 
+    def email_for_web_templates(self) -> str:
+        return self.email or ""
+
 
 @dataclass
 class KeySet:

--- a/csvbase/web/main/bp.py
+++ b/csvbase/web/main/bp.py
@@ -1212,7 +1212,7 @@ def user_settings(username: str) -> Response:
         if timezone not in timezones:
             raise exc.InvalidRequest()
         user.timezone = timezone
-        user.email = request.form["email"]
+        user.email = request.form.get("email")
         svc.update_user(sesh, user)
         sesh.commit()
         flash("Updated settings")

--- a/csvbase/web/templates/user-settings.html
+++ b/csvbase/web/templates/user-settings.html
@@ -11,7 +11,7 @@
           <label for="email" class="form-label">Email address</label>
         </div>
         <div class="col-auto">
-          <input type="email" class="form-control" name="email" value="{{ user.email if user.email is not None else '' }}">
+          <input type="email" class="form-control" name="email" value="{{ user.email if user.email is not none else '' }}">
         </div>
         <div class="col-auto">
           <div class="form-text">Optional.  Can help if you forget your password.</div>

--- a/csvbase/web/templates/user-settings.html
+++ b/csvbase/web/templates/user-settings.html
@@ -11,7 +11,7 @@
           <label for="email" class="form-label">Email address</label>
         </div>
         <div class="col-auto">
-          <input type="email" class="form-control" name="email" value="{{ user.email }}">
+          <input type="email" class="form-control" name="email" value="{{ user.email if user.email is not None else '' }}">
         </div>
         <div class="col-auto">
           <div class="form-text">Optional.  Can help if you forget your password.</div>

--- a/csvbase/web/templates/user-settings.html
+++ b/csvbase/web/templates/user-settings.html
@@ -11,7 +11,7 @@
           <label for="email" class="form-label">Email address</label>
         </div>
         <div class="col-auto">
-          <input type="email" class="form-control" name="email" value="{{ user.email if user.email is not none else '' }}">
+          <input type="email" class="form-control" name="email" value="{{ user.email_for_web_templates() }}">
         </div>
         <div class="col-auto">
           <div class="form-text">Optional.  Can help if you forget your password.</div>

--- a/migrations/versions/cb67ce467141_check_constraint_blank_emails.py
+++ b/migrations/versions/cb67ce467141_check_constraint_blank_emails.py
@@ -19,7 +19,7 @@ depends_on = None
 def upgrade():
     op.execute("DELETE FROM metadata.user_emails WHERE email_address = ''")
     op.create_check_constraint(
-        op.f("ck_email_address_not_blank"),
+        op.f("ck_user_emails_email_address_not_blank"),
         "user_emails",
         "email_address != ''",
         "metadata",
@@ -28,5 +28,8 @@ def upgrade():
 
 def downgrade():
     op.drop_constraint(
-        op.f("ck_email_address_not_blank"), "user_emails", "check", "metadata"
+        op.f("ck_user_emails_email_address_not_blank"),
+        "user_emails",
+        "check",
+        "metadata",
     )

--- a/migrations/versions/cb67ce467141_check_constraint_blank_emails.py
+++ b/migrations/versions/cb67ce467141_check_constraint_blank_emails.py
@@ -22,7 +22,7 @@ def upgrade():
     op.create_check_constraint(
         op.f("ck_user_emails_email_address_not_blank"),
         "user_emails",
-        "email_address != ''",
+        "email_address ~ '@'",
         "metadata",
     )
 

--- a/migrations/versions/cb67ce467141_check_constraint_blank_emails.py
+++ b/migrations/versions/cb67ce467141_check_constraint_blank_emails.py
@@ -21,7 +21,7 @@ def upgrade():
     op.create_check_constraint(
         op.f("ck_email_address_not_blank"),
         "user_emails",
-        "email_address <> ''",
+        "email_address != ''",
         "metadata",
     )
 

--- a/migrations/versions/cb67ce467141_check_constraint_blank_emails.py
+++ b/migrations/versions/cb67ce467141_check_constraint_blank_emails.py
@@ -19,9 +19,14 @@ depends_on = None
 def upgrade():
     op.execute("DELETE FROM metadata.user_emails WHERE email_address = ''")
     op.create_check_constraint(
-        "email_address_blank", "user_emails", "email_address <> ''", "metadata"
+        op.f("ck_email_address_not_blank"),
+        "user_emails",
+        "email_address <> ''",
+        "metadata",
     )
 
 
 def downgrade():
-    op.drop_constraint("email_address_blank", "user_emails", "check", "metadata")
+    op.drop_constraint(
+        op.f("ck_email_address_not_blank"), "user_emails", "check", "metadata"
+    )

--- a/migrations/versions/cb67ce467141_check_constraint_blank_emails.py
+++ b/migrations/versions/cb67ce467141_check_constraint_blank_emails.py
@@ -1,0 +1,27 @@
+"""check constraint blank emails
+
+Revision ID: cb67ce467141
+Revises: 63cd716e7107
+Create Date: 2023-10-08 14:33:09.338971+01:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "cb67ce467141"
+down_revision = "63cd716e7107"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("DELETE FROM metadata.user_emails WHERE email_address = ''")
+    op.create_check_constraint(
+        "email_address_blank", "user_emails", "email_address <> ''", "metadata"
+    )
+
+
+def downgrade():
+    op.drop_constraint("email_address_blank", "user_emails", "check", "metadata")

--- a/migrations/versions/cb67ce467141_check_constraint_blank_emails.py
+++ b/migrations/versions/cb67ce467141_check_constraint_blank_emails.py
@@ -5,6 +5,7 @@ Revises: 63cd716e7107
 Create Date: 2023-10-08 14:33:09.338971+01:00
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -8,7 +8,7 @@ from .utils import random_string
 def test_registering_no_whence(client):
     username = random_string()
     response = client.post(
-        "/register", data=dict(username=username, password="password")
+        "/register", data=dict(username=username, password="password", email="")
     )
     assert response.status_code == 302
     assert response.headers["Location"] == f"/{username}"

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -41,7 +41,7 @@ def test_user_settings__updating_delete_email(sesh, client, test_user):
 
     new_user_obj = svc.user_by_name(sesh, test_user.username)
     assert new_user_obj.timezone == new_timezone
-    assert new_user_obj.email == new_email
+    assert new_user_obj.email is None
 
 
 def test_nonsense_timezone(sesh, client, test_user):

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -25,6 +25,25 @@ def test_user_settings__updating(sesh, client, test_user):
     assert new_user_obj.email == new_email
 
 
+def test_user_settings__updating_delete_email(sesh, client, test_user):
+    set_current_user(test_user)
+
+    settings_url = f"/{test_user.username}/settings"
+    get_resp = client.get(settings_url)
+    assert get_resp.status_code == 200
+
+    new_timezone = "Asia/Tokyo"
+    new_email = ""
+    post_resp = client.post(
+        settings_url, data={"timezone": new_timezone, "email": new_email}
+    )
+    assert post_resp.status_code == 302, post_resp.data
+
+    new_user_obj = svc.user_by_name(sesh, test_user.username)
+    assert new_user_obj.timezone == new_timezone
+    assert new_user_obj.email == new_email
+
+
 def test_nonsense_timezone(sesh, client, test_user):
     set_current_user(test_user)
 


### PR DESCRIPTION
Hello,
An attempt at fixing #47.

HTML forms submits fields left empty as blank strings (or at least flask thinks they are blank strings).
Fixing it client side involves adding a JavaScript function to the submit event for the form to delete fields that are blank but I feel you'd rather not do that.

I just included a check for blank strings in the None checks in create_user and update_user. 
Added a check constrain to the user_emails table as requested in #47. Deletes all user_emails where the email is blank as part of adding that constraint

Changed the user-settings templates to use a function that returns '' if the email is None as otherwise jinja renders the text 'None' in the field.

The only place this might have effect (from what I could see) is when interacting with stripe but there is already a check that the user email contains a vaguely email looking string, and just retries without an email if it fails anyway.

Thanks.