### PR TITLE
User tables not returning non git

### DIFF
--- a/csvbase/svc.py
+++ b/csvbase/svc.py
@@ -476,7 +476,6 @@ def tables_for_user(
         .join(models.User)
         .outerjoin(models.GithubUpstream)
         .filter(models.Table.user_uuid == user_uuid)
-        .filter(models.GithubUpstream.table_uuid == models.Table.table_uuid)
         .order_by(models.Table.created.desc())
     )
     if not include_private:

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,16 +1,33 @@
 from csvbase.web.func import set_current_user
 from .utils import make_user
+from lxml import etree
 
 
-def test_user_view__self(client, test_user, ten_rows):
+def test_user_view__self(client, test_user, ten_rows, private_table):
     set_current_user(test_user)
     resp = client.get(f"/{test_user.username}")
+
+    ten_rows_display_name = test_user.username + "/" + ten_rows.table_name
+    private_table_display_name = test_user.username + "/" + private_table
+
+    page = etree.HTML(resp.text)
+
     assert resp.status_code == 200
+    assert page.xpath(f"//h5/a[text()='{ten_rows_display_name}']")
+    assert page.xpath(f"//h5/a[text()='{private_table_display_name}']")
 
 
-def test_user_view__while_anon(client, test_user, ten_rows):
+def test_user_view__while_anon(client, test_user, ten_rows, private_table):
     resp = client.get(f"/{test_user.username}")
+
+    ten_rows_display_name = test_user.username + "/" + ten_rows.table_name
+    private_table_display_name = test_user.username + "/" + private_table
+
+    page = etree.HTML(resp.text)
+
     assert resp.status_code == 200
+    assert page.xpath(f"//h5/a[text()='{ten_rows_display_name}']")
+    assert not page.xpath(f"//h5/a[text()='{private_table_display_name}']")
 
 
 def test_user_view__other(app, sesh, client, test_user, ten_rows):

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -13,8 +13,10 @@ def test_user_view__self(client, test_user, ten_rows, private_table):
     page = etree.HTML(resp.text)
 
     assert resp.status_code == 200
-    assert page.xpath(f"//h5/a[text()='{ten_rows_display_name}']")
-    assert page.xpath(f"//h5/a[text()='{private_table_display_name}']")
+    assert page.xpath(f"//h5[@class='card-title']/a[text()='{ten_rows_display_name}']")
+    assert page.xpath(
+        f"//h5[@class='card-title']/a[text()='{private_table_display_name}']"
+    )
 
 
 def test_user_view__while_anon(client, test_user, ten_rows, private_table):
@@ -26,8 +28,10 @@ def test_user_view__while_anon(client, test_user, ten_rows, private_table):
     page = etree.HTML(resp.text)
 
     assert resp.status_code == 200
-    assert page.xpath(f"//h5/a[text()='{ten_rows_display_name}']")
-    assert not page.xpath(f"//h5/a[text()='{private_table_display_name}']")
+    assert page.xpath(f"//h5[@class='card-title']/a[text()='{ten_rows_display_name}']")
+    assert not page.xpath(
+        f"//h5[@class='card-title']/a[text()='{private_table_display_name}']"
+    )
 
 
 def test_user_view__other(app, sesh, client, test_user, ten_rows):


### PR DESCRIPTION
Hello, fixes #120,
Removes the filter for githubupstream as this was turning the outerjoin into an inner join. The outerjoin was joining on the table uuid already.
<details>
    <summary>SQL generated</summary>

```
SELECT metadata.tables.table_uuid AS metadata_tables_table_uuid, metadata.tables.user_uuid AS metadata_tables_user_uuid, metadata.tables.public AS metadata_tables_public, metadata.tables.created AS metadata_tables_created, metadata.tables.licence_id AS metadata_tables_licence_id, metadata.tables.table_name AS metadata_tables_table_name, metadata.tables.caption AS metadata_tables_caption, metadata.tables.last_changed AS metadata_tables_last_changed, metadata.tables.backend_id AS metadata_tables_backend_id, metadata.users.username AS metadata_users_username, metadata.github_follows.table_uuid AS metadata_github_follows_table_uuid, metadata.github_follows.last_sha AS metadata_github_follows_last_sha, metadata.github_follows.last_modified AS metadata_github_follows_last_modified, metadata.github_follows.https_repo_url AS metadata_github_follows_https_repo_url, metadata.github_follows.branch AS metadata_github_follows_branch, metadata.github_follows.path AS metadata_github_follows_path 
FROM metadata.tables JOIN metadata.users ON metadata.users.user_uuid = metadata.tables.user_uuid LEFT OUTER JOIN metadata.github_follows ON metadata.tables.table_uuid = metadata.github_follows.table_uuid 
WHERE metadata.tables.user_uuid = %(user_uuid_1)s ORDER BY metadata.tables.created DESC
```

</details>

Added to the tests in user_tests to check tables are found in the page returned