### PR TITLE
Filter on user primary key in tables_for_user

### DIFF
--- a/csvbase/svc.py
+++ b/csvbase/svc.py
@@ -475,7 +475,7 @@ def tables_for_user(
         sesh.query(models.Table, models.User.username, models.GithubUpstream)
         .join(models.User)
         .outerjoin(models.GithubUpstream)
-        .filter(models.Table.user_uuid == user_uuid)
+        .filter(models.User.user_uuid == user_uuid)
         .order_by(models.Table.created.desc())
     )
     if not include_private:


### PR DESCRIPTION
Hello, 
Only noticed this after merging the last PR.

I noticed we are filtering the tables by the user's uuid foreign key on the table but since we are already inner joining the user table I thought it would be better to filter on the user's primary key which would be indexed.

<details>
<summary> SQL Generated</summary>

```

SELECT metadata.tables.table_uuid AS metadata_tables_table_uuid, metadata.tables.user_uuid AS metadata_tables_user_uuid, metadata.tables.public AS metadata_tables_public, metadata.tables.created AS metadata_tables_created, metadata.tables.licence_id AS metadata_tables_licence_id, metadata.tables.table_name AS metadata_tables_table_name, metadata.tables.caption AS metadata_tables_caption, metadata.tables.last_changed AS metadata_tables_last_changed, metadata.tables.backend_id AS metadata_tables_backend_id, metadata.users.username AS metadata_users_username, metadata.github_follows.table_uuid AS metadata_github_follows_table_uuid, metadata.github_follows.last_sha AS metadata_github_follows_last_sha, metadata.github_follows.last_modified AS metadata_github_follows_last_modified, metadata.github_follows.https_repo_url AS metadata_github_follows_https_repo_url, metadata.github_follows.branch AS metadata_github_follows_branch, metadata.github_follows.path AS metadata_github_follows_path 
FROM metadata.tables JOIN metadata.users ON metadata.users.user_uuid = metadata.tables.user_uuid LEFT OUTER JOIN metadata.github_follows ON metadata.tables.table_uuid = metadata.github_follows.table_uuid 
WHERE metadata.users.user_uuid = %(user_uuid_1)s ORDER BY metadata.tables.created DESC

```

</details>

Thanks

(Good excuse to see if actions run on pull requests.)