### PR TITLE
Remove PEP 585-style type hints for compatibility with Python<3.9

### DIFF
--- a/csvbase/comments_svc.py
+++ b/csvbase/comments_svc.py
@@ -3,7 +3,7 @@
 import re
 import secrets
 from dataclasses import dataclass
-from typing import Sequence, Optional
+from typing import Mapping, Sequence, Optional
 from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
@@ -263,7 +263,7 @@ def _next_comment_id(sesh: Session, internal_thread_id: int) -> int:
 
 
 def set_references(
-    sesh: Session, thread: Thread, comment_id: int, references: list[str]
+    sesh: Session, thread: Thread, comment_id: int, references: Sequence[str]
 ) -> None:
     """Set the references for the given thread & comment_id.
 
@@ -282,7 +282,7 @@ def set_references(
     if len(referenced_comments) == 0:
         return
 
-    values: list[dict[str, int]] = [
+    values: Sequence[Mapping[str, int]] = [
         {
             "thread_id": thread.internal_thread_id,
             "comment_id": comment_id,

--- a/csvbase/markdown.py
+++ b/csvbase/markdown.py
@@ -1,5 +1,6 @@
 import re
 import functools
+from typing import Sequence
 
 from marko import Markdown, inline
 from marko.ext.gfm import elements, renderer
@@ -96,6 +97,6 @@ def quote_markdown(md_str: str) -> str:
 REFERENCES_REGEX = re.compile(r"#\d+")
 
 
-def extract_references(md_str: str) -> list[str]:
+def extract_references(md_str: str) -> Sequence[str]:
     """Pull all references (as they are, textually) out of a comment."""
     return re.findall(REFERENCES_REGEX, md_str)

--- a/csvbase/web/app.py
+++ b/csvbase/web/app.py
@@ -177,7 +177,7 @@ def init_app() -> Flask:
         )
 
     @app.context_processor
-    def inject_ua() -> dict[str, Any]:
+    def inject_ua() -> Mapping[str, Any]:
         # UA is occasionally good to know in a template
         return {"user_agent": user_agents.parse(request.headers.get("User-Agent", ""))}
 

--- a/csvbase/web/app.py
+++ b/csvbase/web/app.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from logging import getLogger
 from typing import (
     Any,
+    Dict,
     Mapping,
     Optional,
     Sequence,
@@ -177,7 +178,7 @@ def init_app() -> Flask:
         )
 
     @app.context_processor
-    def inject_ua() -> Mapping[str, Any]:
+    def inject_ua() -> Dict[str, Any]:
         # UA is occasionally good to know in a template
         return {"user_agent": user_agents.parse(request.headers.get("User-Agent", ""))}
 

--- a/csvbase/web/avatars.py
+++ b/csvbase/web/avatars.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from logging import getLogger
 from urllib.parse import urljoin
 import hashlib


### PR DESCRIPTION
I think this makes sense as the Dockerfile is using the 3.8 base image. Alternatively, we could update it to use 3.9 and drop support for 3.8 altogether.

```
$ docker compose logs csvbase
csvbase-1  | [2024-09-12 17:46:56 +0000] [7] [INFO] Starting gunicorn 22.0.0
csvbase-1  | [2024-09-12 17:46:56 +0000] [7] [INFO] Listening at: http://0.0.0.0:6001 (7)
csvbase-1  | [2024-09-12 17:46:56 +0000] [7] [INFO] Using worker: sync
csvbase-1  | [2024-09-12 17:46:56 +0000] [9] [INFO] Booting worker with pid: 9
csvbase-1  | [2024-09-12 17:46:56 +0000] [9] [ERROR] Exception in worker process
csvbase-1  | Traceback (most recent call last):
csvbase-1  |   File "/usr/local/lib/python3.8/site-packages/gunicorn/arbiter.py", line 609, in spawn_worker
csvbase-1  |     worker.init_process()
csvbase-1  |   File "/usr/local/lib/python3.8/site-packages/gunicorn/workers/base.py", line 134, in init_process
csvbase-1  |     self.load_wsgi()
csvbase-1  |   File "/usr/local/lib/python3.8/site-packages/gunicorn/workers/base.py", line 146, in load_wsgi
csvbase-1  |     self.wsgi = self.app.wsgi()
csvbase-1  |   File "/usr/local/lib/python3.8/site-packages/gunicorn/app/base.py", line 67, in wsgi
csvbase-1  |     self.callable = self.load()
csvbase-1  |   File "/usr/local/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 58, in load
csvbase-1  |     return self.load_wsgiapp()
csvbase-1  |   File "/usr/local/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 48, in load_wsgiapp
csvbase-1  |     return util.import_app(self.app_uri)
csvbase-1  |   File "/usr/local/lib/python3.8/site-packages/gunicorn/util.py", line 371, in import_app
csvbase-1  |     mod = importlib.import_module(module)
csvbase-1  |   File "/usr/local/lib/python3.8/importlib/__init__.py", line 127, in import_module
csvbase-1  |     return _bootstrap._gcd_import(name[level:], package, level)
csvbase-1  |   File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
csvbase-1  |   File "<frozen importlib._bootstrap>", line 991, in _find_and_load
csvbase-1  |   File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
csvbase-1  |   File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
csvbase-1  |   File "<frozen importlib._bootstrap_external>", line 843, in exec_module
csvbase-1  |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
csvbase-1  |   File "/usr/local/lib/python3.8/site-packages/csvbase/web/app.py", line 40, in <module>
csvbase-1  |     from .blog.bp import bp as blog_bp
csvbase-1  |   File "/usr/local/lib/python3.8/site-packages/csvbase/web/blog/bp.py", line 12, in <module>
csvbase-1  |     from csvbase.markdown import render_markdown
csvbase-1  |   File "/usr/local/lib/python3.8/site-packages/csvbase/markdown.py", line 99, in <module>
csvbase-1  |     def extract_references(md_str: str) -> list[str]:
csvbase-1  | TypeError: 'type' object is not subscriptable
csvbase-1  | [2024-09-12 17:46:56 +0000] [9] [INFO] Worker exiting (pid: 9)
csvbase-1  | [2024-09-12 17:46:56 +0000] [7] [ERROR] Worker (pid:9) exited with code 3
csvbase-1  | [2024-09-12 17:46:56 +0000] [7] [ERROR] Shutting down: Master
csvbase-1  | [2024-09-12 17:46:56 +0000] [7] [ERROR] Reason: Worker failed to boot.
```