### PR TITLE
Alternate version of permissions

### DIFF
--- a/csvbase/auth.py
+++ b/csvbase/auth.py
@@ -5,7 +5,7 @@ from typing import Union
 from typing_extensions import Literal
 from uuid import UUID
 
-from sqlalchemy import cast, types as satypes
+from sqlalchemy import types as satypes
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.expression import select, literal_column, union_all
 
@@ -56,7 +56,7 @@ def ensure_table_access(
 
     # Users's current permissions
     table_permissions = _build_table_permissions_subselect(
-        sesh, current_user.user_uuid
+        sesh, current_user.user_uuid  # type: ignore
     ).subquery()
 
     # Check that user has access to do what they are currently doing

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -15,7 +15,9 @@ def test_auth__can_write_own_tables(sesh, test_user, ten_rows):
         auth.ensure_table_access(sesh, ten_rows, "write")
 
 
-def test_auth__cannot_write_other_peoples_tables(sesh, test_user, ten_rows, crypt_context):
+def test_auth__cannot_write_other_peoples_tables(
+    sesh, test_user, ten_rows, crypt_context
+):
     other_user = utils.make_user(sesh, crypt_context)
     with utils.current_user(other_user):
         with pytest.raises(RuntimeError):


### PR DESCRIPTION
This code (currently not used) implements an alternate way of checking permissions that will be more flexible.

In particular it's fast (because the permissions check is done through SQL instead of Python) and can easily be expanded to work with "bearer" credentials (ie: share tokens) or RBAC, where the user is a member of a group that grants them extra permissions.